### PR TITLE
Update openapitools-js.json

### DIFF
--- a/openapitools-js.json
+++ b/openapitools-js.json
@@ -5,7 +5,7 @@
     "generators": {
       "client": {
         "generatorName": "typescript-axios",
-        "output": ".",
+        "output": "./src",
         "glob": "openapi.yaml",
         "templateDir": "templates-js",
         "additionalProperties": {


### PR DESCRIPTION
This puts source files in a `src` directory instead of at the top-level.