### PR TITLE
revert: "fix: resolve fields of type `Set` as `Array`"

### DIFF
--- a/openapitools-js.json
+++ b/openapitools-js.json
@@ -11,10 +11,7 @@
         "additionalProperties": {
           "modelPropertyNaming": "original",
           "useSingleRequestParameter": "true"
-        },
-        "typeMappings": {
-          "set": "Array"
-        },
+        }
       }
     }
   }


### PR DESCRIPTION
Reverts Kong/openapi-generator-config#3

It's causing the generate SDK action to fail
https://github.com/Kong/sdk-konnect-js-dev/actions/runs/13679534503/job/38254835376