### PR TITLE
Split API and Models in to their own files

### DIFF
--- a/openapitools-js.json
+++ b/openapitools-js.json
@@ -10,7 +10,10 @@
         "templateDir": "templates-js",
         "additionalProperties": {
           "modelPropertyNaming": "original",
-          "useSingleRequestParameter": "true"
+          "useSingleRequestParameter": "true",
+          "withSeparateModelsAndApi": "true",
+          "apiPackage": "api",
+          "modelPackage": "models"
         },
         "typeMappings": {
           "set": "Array"


### PR DESCRIPTION
Rather than generating one giant `api.ts` file, this splits APIs in to their own files. There should be no breaking change as everything is exported by default.

```js
export * from './api/acls-api';
export * from './api/aimanager-models-api';
export * from './api/apiapi';
export * from './api/apiattributes-api';
export * from './api/apidocumentation-api';
export * from './api/apiimplementation-api';
export * from './api/apikeys-api';
export * from './api/apiproduct-documentation-api';
export * from './api/apiproduct-version-specification-api';
export * from './api/apiproduct-versions-api';
export * from './api/apiproducts-api';
...etc...
```