### PR TITLE
feat: bump openapi-generator to 7.2.0

### DIFF
--- a/openapitools-js.json
+++ b/openapitools-js.json
@@ -1,7 +1,7 @@
 {
   "spaces": 2,
   "generator-cli": {
-    "version": "6.2.1",
+    "version": "7.2.0",
     "generators": {
       "client": {
         "generatorName": "typescript-axios",


### PR DESCRIPTION
**summary:**
- bump openapi-generator from `6.2.1` -> `7.2.0`
  - required to resolve bug in SDK generation where we have a nullable enum string
  - I believe [this](https://github.com/OpenAPITools/openapi-generator/commit/a60100245135a4591e99637f2de4d474cc4c539b) is the relevant upstream fix
  - we ran into a similar issue in the past, see this [slack thread](https://kongstrong.slack.com/archives/C068AHKGSPQ/p1702337863355359?thread_ts=1701893452.530959&cid=C068AHKGSPQ)
  - running up against this issue now, see this [slack thread](https://kongstrong.slack.com/archives/C068AHKGSPQ/p1755096852881019)
  
  
**verification:**

Given the following OAS  
```yaml
openapi: 3.0.3
info:
  title: Test SDK Generation
  version: 1.0.0
tags:
  - name: Test
    description: Test SDK Generation
paths:
  /scorecards:
    post:
      summary: Test SDK Generation
      operationId: test-sdk-generation
      description: Testing SDK Generation
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              required:
                - parameters
              properties:
                parameters:
                  type: string
                  enum:
                    - null
                  nullable: true
      responses:
        '200':
          description: 'success'
      tags:
        - Test
```

version 6.2.1 generates the following interface in the SDK (notice that `parameters` **cannot** be set to `null`)

```typescript
export interface TestSdkGenerationRequest {
    /**
     * 
     * @type {string}
     * @memberof TestSdkGenerationRequest
     */
    'parameters': TestSdkGenerationRequestParametersEnum;
}

export const TestSdkGenerationRequestParametersEnum = {
    Null: 'null'
} as const;

export type TestSdkGenerationRequestParametersEnum = typeof TestSdkGenerationRequestParametersEnum[keyof typeof TestSdkGenerationRequestParametersEnum];
```

version 7.2.0 generates the following interface in SDK (notice that `parameters` **can** be set to `null`)

```typescript
export interface TestSdkGenerationRequest {
    /**
     * 
     * @type {string}
     * @memberof TestSdkGenerationRequest
     */
    'parameters': TestSdkGenerationRequestParametersEnum | null;
}

export const TestSdkGenerationRequestParametersEnum = {
    Null: 'null'
} as const;

export type TestSdkGenerationRequestParametersEnum = typeof TestSdkGenerationRequestParametersEnum[keyof typeof TestSdkGenerationRequestParametersEnum];
```